### PR TITLE
Process same letter chars more efficiently

### DIFF
--- a/include/repair.h
+++ b/include/repair.h
@@ -30,6 +30,7 @@ void printPhraseList();
 bool checkExpPairs();
 bool checkPhraseBoundaries();
 bool checkSourceBoundaries();
+double calculateMemoryUsage(size_t curr_mem, size_t prev_mem);
 
 // Necessary functions
 uint64_t calculateParseBytes(std::ifstream& pfile);


### PR DESCRIPTION
If we are processing a same letter char pair and the boundaries can form the pair multiple times, add all the pairs to exp phrase at once rather than one by one.